### PR TITLE
Andrew edits

### DIFF
--- a/bescr3/index.md
+++ b/bescr3/index.md
@@ -38,10 +38,10 @@ This new version of the Basic ESC is based on the BLHeli_S ESC design, providing
 
 ## Quick Start
 
-1. Connect the three motor wires to the motor. The order of connections does not matter, however, switching any two wires will change the direction of the motor. The output phases A, B, and C are completely interchangeable
+1. Connect the three motor wires to the motor. The order of connections does not matter; however, switching any two wires will change the direction of the motor. The output phases A, B, and C are completely interchangeable
 2. Connect the red power wire and black ground wire to a power source like a battery. You will hear three beeps in rising pitch from the motor indicating all three phases are connected. 
-3. Connect the signal cable to your signal source like an RC radio receiver or microcontroller board. The white wire is the signal wire. 
-4. Send a stopped signal (1500 microseconds) for a few seconds to initialize the ESC. You will hear two tones indicating initialization, and then you can send a signal from 1100-1900µs to operate the thruster.
+3. Connect the signal cable to your signal source like a RC radio receiver or microcontroller board. The white wire is the signal wire. 
+4. Send a stopped signal (1500 microseconds) for a few seconds to initialize the ESC. You will hear two tones indicating initialization, and then you can send a signal from 1100-1900 µs to operate the thruster.
 
 # Specifications
 
@@ -61,7 +61,7 @@ This new version of the Basic ESC is based on the BLHeli_S ESC design, providing
 | Length        | 35 mm         | 1.38 in       |
 | Width         | 17.1 mm       | 0.67 in     |
 | Height        | 5.5 mm        | 0.22 in      |
-| Weight        | 16.3g         | 0.036lb
+| Weight        | 16.3 g         | 0.036 lb
 | Power Connectors | Spade terminals for No. 6 screw    |
 | Motor Connectors | Tinned wire ends           |
 | Signal Connector | 3-pin servo connector (0.1" pitch) (ground, blank, signal) |

--- a/brov2-heavy/index.md
+++ b/brov2-heavy/index.md
@@ -159,7 +159,7 @@ To install the new thruster guards, you will need the following parts and tools:
 -	8 x Heavy Guard Mounting Brackets
 -	2 x Heavy Guards
 -	1 x Threadlocker
--	1x #1 Phillips head screwdriver
+-	1 x #1 Phillips head screwdriver
 
 1. Apply one drop of threadlocker to each of the M4x16mm screws. Roll the screws around on a paper towel to evenly spread the threadlocker and to remove excess threadlocker.
 2. Install 4 of the thruster guard mounting brackets on the outside of the frame using 4 M4x16 screws as shown below.
@@ -202,8 +202,8 @@ To install the new buoyancy blocks and fairings, you will need the following par
 -	2 x Heavy additional buoyancy blocks
 -	2 x Heavy fairings
 -	1 x Bag of 4 fairing screws
--	1x #1 Phillips head screwdriver
--   1x #2 Phillips head screwdriver
+-	1 x #1 Phillips head screwdriver
+-   1 x #2 Phillips head screwdriver
 
 1.	 Reinstall Original Fairing Blocks onto ROV by installing the screws through the center panels and into the fairings.
 <img src="/brov2-heavy/cad/heavy-step-3.PNG" class="img-responsive img-center" style="max-width:800px"  />
@@ -214,20 +214,20 @@ To install the new buoyancy blocks and fairings, you will need the following par
 <img src="/brov2-heavy/cad/heavy-tutorial-17.jpg" class="img-responsive img-center" style="max-width:800px"  />
 <img src="/brov2-heavy/cad/heavy-tutorial-21.jpg" class="img-responsive img-center" style="max-width:800px"  />
 
-## Mounting Additonal Ballast to the Frame
+## Mounting Additional Ballast to the Frame
 
 To mount the ballast to the frame you need the following parts and tools:
 
 - 7 x 200g ballast weights (from original BlueROV2 Kit)
 - 3 x 200g ballast weights (from Heavy Retrofit Kit)
-- 10 x 8-16 Thread, 5/8” Long, Thread-Forming Screw
-- 1 x #2 phillips head screwdriver
+- 10 x 8-16 Thread, 5/8” Long, Thread-Forming Screws
+- 1 x #2 Phillips head screwdriver
 
 To get the longest battery life and the best driving experience, it is important to have the ROV close to balanced from front to back in water and close to neutrally buoyant. The Heavy Retrofit kit adds a bit of weight and more buoyancy to the ROV, so it will need to be retrimmed based on your operating conditions. Trimming the ballast may involve a bit of trial and error. The pictures below should provide a good starting point for mounting additonal ballast.
 
 # Software Setup
 
-Finally, before operating your ROV, we need to update the software configuration. Begin by powering on your ROV, connect it to your computer, and open QGroundControl.
+Finally, before operating your ROV, we need to update the software configuration. Begin by powering on your ROV, connecting it to your computer, and opening QGroundControl.
 
 ## Load New Parameters
 
@@ -267,7 +267,7 @@ Push the buttons once, or hold them down to adjust the roll and pitch angle of t
 	
 2. Using the joystick button function _roll_pitch_toggle_ 
 
-This is an advanced function, to setup this function, please reference the [ArduSub Button Setup page](https://www.ardusub.com/getting-started/initial-setup.html#button-setup) (This function is very developmental, use with caution)
+This is an advanced function. To setup this function, please reference the [ArduSub Button Setup page](https://www.ardusub.com/getting-started/initial-setup.html#button-setup) (This function is very developmental, use with caution)
 
 Push the button to toggle the function of one joystick between controlling forward/lateral input and controlling roll/pitch input
 <img src="/brov2-heavy/cad/joystick-stick-mode.png" class="img-responsive img-center" style="max-width:800px"  />

--- a/brov2-heavy/index.md
+++ b/brov2-heavy/index.md
@@ -17,7 +17,7 @@ nav:
 - - Reassemble BlueROV2: reassemble-bluerov2
 - - Cable Management: cable-management
 - - Install New Buoyancy Blocks: install-new-buoyancy-blocks-and-fairings
-- - Mounting Additonal Ballast: mounting-additonal-ballast-to-the-frame
+- - Mounting Additional Ballast: mounting-additional-ballast-to-the-frame
 - Software Setup: software-setup
 - - Load New Parameters: load-new-parameters
 - - Configure Motor Directions: configure-motor-directions

--- a/brov2/specifications.md
+++ b/brov2/specifications.md
@@ -152,7 +152,7 @@ The batteries can be changed in about 30 seconds.
 ## Camera
 
 | Field of View (Underwater) | 110 degrees (horizontal)                                                              |                                                      
-| Light Sensitivity          | 0.01[lux](https://en.wikipedia.org/wiki/Lux#Illuminance)                              |
+| Light Sensitivity          | 0.01 [lux](https://en.wikipedia.org/wiki/Lux#Illuminance)                              |
 | Resolution                 | 1080p                                                                                 |
 
 ## Control System

--- a/newton-gripper/index.md
+++ b/newton-gripper/index.md
@@ -32,7 +32,7 @@ manual-links:
 
 # Introduction
 
-The _Newton Gripper_ is a sealed single function manipulator which can operate at depths of up to 300 meters. The *Newton Gripper* can be smoothly opened or closed with a servo PWM signal to provide the *BlueROV2* and other subsea vehicles with the ability to interact with the subsea environment to retrieve objects, attach recovery lines, or free a snagged tether.
+The _Newton Gripper_ is a sealed, single function manipulator which can operate at depths of up to 300 meters. The *Newton Gripper* can be smoothly opened or closed with a servo PWM signal to provide the *BlueROV2* and other subsea vehicles with the ability to interact with the subsea environment to retrieve objects, attach recovery lines, or free a snagged tether.
 
 <i class="fa fa-exclamation-triangle fa-fw fa-2x text-warning"></i>
 **Keep fingers and other body parts away from the gripper when operating!** It's strong and has the potential to do some damage. Notify other crew members to do the same.
@@ -67,14 +67,14 @@ The _Newton Gripper_ is a sealed single function manipulator which can operate a
 | ------------- | --------- |
 |   **Mechanical**    |
 |--------------|--------------|
-| Grip Force (at tip) | 97N | 22lbf |
-| Grip Force (in middle) | 124N | 28lbf |
+| Grip Force (at tip) | 97N | 22lb<sup>f</sup> |
+| Grip Force (in middle) | 124N | 28lb<sup>f</sup> |
 | Linear Piston Travel | 15mm | 0.59in
 | Jaw Opening | 70mm | 2.75 in |
 | Time to Open/Close | 1.6 secs |
 |  **Cable**  |
 | Cable Diameter | 3.8 mm | 0.15 in |
-| Cable Length | 635mm | 25 in |
+| Cable Length | 635 mm | 25 in |
 | Cable Jacket | Black Urethane |
 | Conductor Insulation | Acid-Etched FEP |
 | Conductor Gauge | 20 AWG |
@@ -217,7 +217,7 @@ To mount the Newton Gripper to the BlueROV2 Frame, you will need the following p
 
 To clean up the external Newton Gripper cable, you will need the bag of 5 zip ties and your scissors/wire cutters.
 
-The primary goal of cable management is to prevent the wires from getting cut by the propellers. Make sure to check that no wire can reach a propeller after you have finished routing the Newton Gripper cable. Below are some examples of what the cable routing should look like.
+The primary goal of cable management is to prevent the wires from getting cut by the propellers. Make sure to check that no wires can reach the propellers after you have finished routing the Newton Gripper cable. Below is an example of what the cable routing should look like.
 
 <img src="/newton-gripper/cad/gripper-tutorial-cable-routing.jpg" class="img-responsive img-center" style="max-width:800px"  />
 
@@ -227,7 +227,7 @@ To install the new buoyancy blocks and fairings, you will need the following par
 
 -	16 x Fairing screws that were placed off to the side during disassembly
 -	4 x Fairings with buoyancy installed that were placed off to the side during disassembly
--	1x #1 Phillips head screwdriver
+-	1 x #1 Phillips head screwdriver
 
 1.	 Reinstall Original Fairing Blocks onto ROV by installing the screws through the center panels and into the fairings.
 <img src="/newton-gripper/cad/gripper-tutorial-2.PNG" class="img-responsive img-center" style="max-width:800px"  />
@@ -236,9 +236,9 @@ To install the new buoyancy blocks and fairings, you will need the following par
 
 To adjust the amount or position of ballast on the frame you need the following parts and tools:
 
-- 7 x 200g ballast weights (from original BlueROV2 Kit)
-- 10 x 8-16 Thread, 5/8” Long, Thread-Forming Screw
-- 1 x #2 phillips head screwdriver
+- 7 x 200g Ballast weights (from original BlueROV2 Kit)
+- 10 x 8-16 Thread, 5/8” Long, Thread-Forming Screws
+- 1 x #2 Phillips head screwdriver
 
 To get the longest battery life and the best driving experience, it is important to have the ROV close to balanced from front to back in water and close to neutrally buoyant. The Newton Gripper adds a bit of weight to the ROV, so it will need to be retrimmed based on your operating conditions. Trimming the ballast may involve a bit of trial and error.
 

--- a/payload-skid/index.md
+++ b/payload-skid/index.md
@@ -59,7 +59,7 @@ All 3D models are provided in zip archives containing the follow file types:
 
 # Usage
 
-Assemble according to the below steps, and the Payload Skid will allow you to mount two additional Lumens, twelve additional ballast weights, and three additional 3" watertight enclosures or one additional 4" watertight enclosure. Note that you may have to add more than a few ballast weights to get your BlueROV2 back to neutral buoyancy if your additional watertight enclosures are mostly empty! The chart below suggests the approximate number of additional 200g ballast weights you will need to add to to achieve this, they can be mounted in any combination on the BlueROV2 or Payload Skid as necessary. 
+Assemble according to the below steps, and the Payload Skid will allow you to mount two additional Lumens, twelve additional ballast weights, and three additional 3" watertight enclosures or one additional 4" watertight enclosure. Note that you may have to add more than a few ballast weights to get your BlueROV2 back to neutral buoyancy if your additional watertight enclosures are mostly empty! The chart below suggests the approximate number of additional 200g ballast weights you will need to add to achieve this. They can be mounted in any combination on the BlueROV2 or Payload Skid as necessary. 
 
 |  **Suggested Additional Ballast Weights**  |
 | ------------- | --------- |
@@ -101,7 +101,7 @@ Using four M4x14 screws, attach a 3" or 4" watertight enclosure clamp to top of 
 
 <img src="/payload-skid/cad/payload-step-5.png" class="img-responsive img-center" style="max-width:800px"  />
 
-Using four M3x12 screws, clamp your 3" or 4" watertight enclosure into place with the other clamp. Install all four screws loosly at first and then slowly tighten them on both sides evenly. Keep the enclosure approximately centered in the clamps. Using thread-locker is recommended. Repeat steps 4 and 5 if you are mounting additonal watertight enclosures to the side panels, note that you will only be able to mount three enclosures on the inside of the Payload Skid if they are all 3" models.
+Using four M3x12 screws, clamp your 3" or 4" watertight enclosure into place with the other clamp. Install all four screws loosely at first and then slowly tighten them on both sides evenly. Keep the enclosure approximately centered in the clamps. Using thread-locker is recommended. Repeat steps 4 and 5 if you are mounting additonal watertight enclosures to the side panels, note that you will only be able to mount three enclosures on the inside of the Payload Skid if they are all 3" models.
 
 ## Step 6: Installing Additional Lights
 

--- a/thrusters/index.md
+++ b/thrusters/index.md
@@ -84,9 +84,9 @@ A slight clicking noise is normal, especially when operated dry. It is caused by
 |----------------------------------------------------------------------------------------|
 |                                 **Performance**                                        |
 | -------------------------------------------------------|-------------------------------|
-| Maximum Forward Thrust                                 | 2.36 kgf      | 5.2 lbf       |
-| Maximum Reverse Thrust                                 | 1.85 kgf      | 4.1 lbf       |
-| Minimum Thrust                                         | 0.01 kgf      | 0.02 lbf      |
+| Maximum Forward Thrust                                 | 2.36 kg<sub>f</sub>      | 5.2 lb<sub>f</sub>       |
+| Maximum Reverse Thrust                                 | 1.85 kg<sub>f</sub>      | 4.1 lb<sub>f</sub>       |
+| Minimum Thrust                                         | 0.01 kg<sub>f</sub>      | 0.02 lb<sub>f</sub>      |
 | Rotational Speed                                       | 300-4200 rev/min              |
 | -------------------------------------------------------|-------------------------------| 
 |                                 **Electrical**                                         |

--- a/thrusters/t200.md
+++ b/thrusters/t200.md
@@ -80,11 +80,11 @@ A slight clicking noise is normal, especially when operated dry. It is caused by
 | -----------------------------------------------------------------------------------|
 |                                    **Performance**                                 |
 | -----------------------------------------------------------------------------------|
-| Maximum Forward Thrust @ 16V                       | 5.1 kgf       | 11.2 lbf      |
-| Maximum Reverse Thrust @ 16V                       | 4.1 kgf       | 9.0 lbf       |
-| Maximum Forward Thrust @ 12V                       | 3.55 kgf      | 7.8 lbf       |
-| Maximum Reverse Thrust @ 12V                       | 3.0 kgf       | 6.6 lbf       |
-| Minimum Thrust                                     | 0.01 kgf      | 0.02 lbf      |
+| Maximum Forward Thrust @ 16V                       | 5.1 kg<sub>f</sub>       | 11.2 lb<sub>f</sub>      |
+| Maximum Reverse Thrust @ 16V                       | 4.1 kg<sub>f</sub>       | 9.0 lb<sub>f</sub>       |
+| Maximum Forward Thrust @ 12V                       | 3.55 kg<sub>f</sub>      | 7.8 lb<sub>f</sub>       |
+| Maximum Reverse Thrust @ 12V                       | 3.0 kg<sub>f</sub>       | 6.6 lb<sub>f</sub>       |
+| Minimum Thrust                                     | 0.01 kg<sub>f</sub>      | 0.02 lb<sub>f</sub>      |
 | Rotational Speed                                   | 300-3800 rev/min              |
 | ---------------------------------------------------|-------------------------------|
 |                                    **Electrical**                                  |        


### PR DESCRIPTION
edits in brov2, brov2-heavy, and payload-skid

indicator LED has a missing image in the docs.bluerobotics.com page

edits and questions in the text doc below:
[doc edits 6-19.txt](https://github.com/bluerobotics/bluerobotics.github.io/files/2116351/doc.edits.6-19.txt)

