### PR TITLE
Redirect BlueROV2-Heaky retrofit kit assembly instructions to new docs

### DIFF
--- a/brov2-heavy/index.md
+++ b/brov2-heavy/index.md
@@ -24,6 +24,8 @@ store-links:
 manual-links:
 - BlueROV2: /brov2/assembly/
 - T200: /thrusters/t200
+
+redirect: https://www.bluerobotics.com/learn/bluerov2-heavy-configuration-retrofit-kit-installation/
 ---
 
 <img src="/brov2-heavy/cad/heavy-tutorial-21.jpg" class="img-responsive img-center" style="max-width:350px"  />


### PR DESCRIPTION
Fix https://github.com/bluerobotics/product-documentation/issues/39