### PR TITLE
Add some missing redirects

### DIFF
--- a/bar02/index.md
+++ b/bar02/index.md
@@ -16,6 +16,8 @@ store-links:
 manual-links:
 - Celsius Temperature Sensor: /celsius
 - I2C Level Converter: /level-converter
+
+redirect: https://www.bluerobotics.com/store/sensors-sonars-cameras/sensors/bar02-sensor-r1-rp/
 ---
 
 <img src="bar-02-1.jpg" class="img-responsive" style="max-width:900px"  />

--- a/bar100/index.md
+++ b/bar100/index.md
@@ -16,6 +16,8 @@ store-links:
 manual-links:
 - Celsius Temperature Sensor: /celsius
 - I2C Level Converter: /level-converter
+
+redirect: https://www.bluerobotics.com/store/sensors-sonars-cameras/sensors/bar100-sensor-r1/
 ---
 
 <img src="/bar100/cad/BAR100-5.png" class="img-responsive" style="max-width:900px"  />

--- a/bar30/index.md
+++ b/bar30/index.md
@@ -15,6 +15,8 @@ store-links:
 manual-links:
 - Celsius Temperature Sensor: /celsius
 - I2C Level Converter: /level-converter
+
+redirect: https://www.bluerobotics.com/store/sensors-sonars-cameras/sensors/bar30-sensor-r1/
 ---
 
 <img src="/bar30/cad/pressure-sensor-4.png" class="img-responsive" style="max-width:900px"  />

--- a/bescr3/index.md
+++ b/bescr3/index.md
@@ -14,6 +14,8 @@ store-links:
 manual-links:
 - T100/T200 Thrusters: /thrusters/
 - M100 Motor: /thrusters/motors/
+
+redirect: https://www.bluerobotics.com/store/thrusters/speed-controllers/besc30-r3/
 ---
 # Example Code
 


### PR DESCRIPTION
I missed some items during that first pass.

There are some pages still left without redirects, such as the [docs for the original BlueROV](http://docs.bluerobotics.com/bluerov/) and [batteries guide](http://docs.bluerobotics.com/battery/). Should we do something to them?