### PR TITLE
power-sense-module.md: remove redirect

### DIFF
--- a/power-sense-module/index.md
+++ b/power-sense-module/index.md
@@ -16,7 +16,6 @@ store-links:
 manual-links:
 - BlueROV2: /brov2
 
-redirect: https://www.bluerobotics.com/store/comm-control-power/elec-packages/psm-asm-r2-rp/
 ---
 
 <img src="/power-sense-module/cad/PSM-Banner.JPG" class="img-responsive" style="max-width:900px"  />


### PR DESCRIPTION
We don't have data for the power-sense-module r1 available elsewhere, so this page should be accessible for users who still have it.